### PR TITLE
Implement OmniAvatar node using official API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
-# Omniavatar
+# OmniAvatar
+
+This repository contains a custom [ComfyUI](https://github.com/comfyanonymous/ComfyUI) node that wraps the open-source **OmniAvatar 14B** model. The node is called **"OmniAvatar All-in-One (14B)"** and accepts a portrait image, an audio file, and a text prompt to generate a talking video.
+
+## Files
+
+- `__init__.py` – 暴露节点入口。
+- `node_omniavatar_allinone.py` – 节点实现，直接调用 OmniAvatar 推理接口。
+- `requirements.txt` – 基础依赖列表。
+- `assets/icon.png` – 节点图标占位。
+
+## 安装步骤
+
+1. **获取 OmniAvatar 源码及模型**
+   ```bash
+   git clone https://github.com/Omni-Avatar/OmniAvatar
+   ```
+   下载 14B 权重和配置文件，并记录其路径。
+2. **设置 PYTHONPATH** 将 OmniAvatar 的 `src` 目录加入环境变量：
+   ```bash
+   export PYTHONPATH=/path/to/OmniAvatar/src:$PYTHONPATH
+   ```
+3. **安装依赖**
+   ```bash
+   pip install -r requirements.txt
+   ```
+   其余依赖请参考 OmniAvatar 仓库提供的 requirements。
+4. 将本仓库放入 ComfyUI 的 `custom_nodes` 目录下。
+
+## 使用说明
+
+启动 ComfyUI 后，节点位于 **OmniAvatar** 分类。需要提供：
+
+- `portrait_image`：人像图像。
+- `audio_file`：音频文件路径。
+- `prompt_text`：文本提示。
+- `config_path`：OmniAvatar 配置文件路径。
+- `ckpt_path`：模型权重路径。
+
+节点执行时会暂存输入，并调用 `OmniAvatar.infer` 生成视频，控制台会显示进度条。
+

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,6 @@
+from .node_omniavatar_allinone import OmniAvatarAllInOneNode
+
+NODE_CLASS_MAPPINGS = {"OmniAvatarAllInOneNode": OmniAvatarAllInOneNode}
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "OmniAvatarAllInOneNode": "OmniAvatar All-in-One (14B)"
+}

--- a/node_omniavatar_allinone.py
+++ b/node_omniavatar_allinone.py
@@ -1,0 +1,94 @@
+"""ComfyUI 节点：OmniAvatar All-in-One (14B)"""
+
+import os
+import shutil
+import tempfile
+from PIL import Image
+from tqdm import tqdm
+
+# 导入 OmniAvatar 官方推理接口
+try:
+    from src.inference.inference_avatar import OmniAvatar
+except Exception as e:  # noqa: BLE001 - ignore import error for packaging
+    OmniAvatar = None  # 运行环境未提供 OmniAvatar 源码
+
+
+def _save_audio(src: str, dst: str) -> None:
+    """保存或拷贝音频文件"""
+    if os.path.isfile(src):
+        shutil.copy(src, dst)
+    else:
+        with open(dst, "wb") as f:
+            f.write(src)
+
+
+class OmniAvatarAllInOneNode:
+    """在 ComfyUI 中调用 OmniAvatar 14B 模型的节点"""
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("video_path",)
+    FUNCTION = "run"
+    CATEGORY = "OmniAvatar"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "portrait_image": ("IMAGE", {}),
+                "audio_file": ("STRING", {"default": ""}),
+                "prompt_text": ("STRING", {"default": "你好，欢迎体验OmniAvatar"}),
+                "config_path": ("STRING", {"default": "configs/14B.yaml"}),
+                "ckpt_path": ("STRING", {"default": "checkpoints/OmniAvatar14B.pth"}),
+            }
+        }
+
+    def __init__(self):
+        self._models = {}
+
+    def _get_model(self, config_path: str, ckpt_path: str):
+        """获取或创建模型实例"""
+        key = f"{config_path}|{ckpt_path}"
+        if key not in self._models:
+            if OmniAvatar is None:  # pragma: no cover - 环境缺少源码
+                raise RuntimeError("未找到 OmniAvatar 源码，请检查 PYTHONPATH")
+            self._models[key] = OmniAvatar(config_path=config_path, ckpt_path=ckpt_path)
+        return self._models[key]
+
+    def run(
+        self,
+        portrait_image: Image.Image,
+        audio_file: str,
+        prompt_text: str,
+        config_path: str,
+        ckpt_path: str,
+    ):
+        """执行 OmniAvatar 推理，返回视频路径"""
+
+        tmpdir = tempfile.mkdtemp()
+        image_path = os.path.join(tmpdir, "input.png")
+        audio_path = os.path.join(tmpdir, "input.wav")
+        video_path = os.path.join(tmpdir, "output.mp4")
+
+        # 保存输入图片
+        Image.fromarray(portrait_image).save(image_path)
+        # 保存音频
+        _save_audio(audio_file, audio_path)
+
+        # 创建或获取模型实例
+        model = self._get_model(config_path, ckpt_path)
+
+        # 调用官方推理接口并显示进度
+        with tqdm(total=1, desc="OmniAvatar") as pbar:
+            model.infer(
+                img_path=image_path,
+                audio_path=audio_path,
+                save_path=video_path,
+                text=prompt_text,
+            )
+            pbar.update(1)
+
+        return (video_path,)
+
+
+NODE_CLASS_MAPPINGS = {"OmniAvatarAllInOneNode": OmniAvatarAllInOneNode}
+NODE_DISPLAY_NAME_MAPPINGS = {"OmniAvatarAllInOneNode": "OmniAvatar All-in-One (14B)"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+torch
+numpy==1.26.4
+ffmpeg-python
+omegaconf
+librosa==0.10.2.post1
+tqdm
+peft==0.15.1
+transformers==4.52.3
+scipy==1.14.0
+xfuser==0.4.1
+ftfy
+einops
+Pillow


### PR DESCRIPTION
## Summary
- restructure repository to expose node files at repo root
- implement `OmniAvatarAllInOneNode` with calls to `OmniAvatar` official API and Chinese comments
- document setup instructions and usage in Chinese
- update requirements to match official dependencies
- add placeholder icon asset

## Testing
- `python -m py_compile __init__.py node_omniavatar_allinone.py`


------
https://chatgpt.com/codex/tasks/task_e_687f4eb1910c83259b32a58b045d6aa3